### PR TITLE
Fix typo in sponsor plan description

### DIFF
--- a/_data/events/SQLSat1128.yml
+++ b/_data/events/SQLSat1128.yml
@@ -167,7 +167,7 @@ sponsors:
 sponsorplan: |
     <p>Day of Data Jacksonville 2026 #1128 is an entire day conference related to the data professional and data technology. Day of Data is organized by Jax Data, a 501c3 non-profit organization.</p>
     <p>With the help of a lot of Volunteers, we provide excellent sessions, refreshments, and lunch giving ample opportunities to interact with local professionals. In addition, we ensure adequate and comfortable We work hard to 
-    ensure that the Day of Data is an excellent experience for all, especially our Sponsors, without whom the event would not happen. Therefore, we aim to present at least six opportunities to route each attended to your booth.</p>
+    ensure that the Day of Data is an excellent experience for all, especially our Sponsors, without whom the event would not happen. Therefore, we aim to present at least six opportunities to route each attendee to your booth.</p>
     <p>This is our 18th annual data conference event Day of Data, which has grown steadily since being the #3 SQL Saturday in 2006. With the support of our Sponsors, it remains free and open to the public. For 2017-2019, SQL Saturday Jacksonville 
     attracted over 750 attendee registrations, the 3rd largest SQL Saturday in the United States. We had 50+ sessions led by 50+ world-class presenters. In 2022, 2023, 2024 and 2025, Jacksonville hosted the largest SQL Saturday in the world for the year. 
     We anticipate sustaining our year-over-year increase in attendance for Day of Data. The volunteer organizers of Day of Data Jacksonville 2026 are proud to offer the following Sponsorship opportunities.</p>


### PR DESCRIPTION
Corrected the word 'attended' to 'attendee' in the sponsor plan description.