### PR TITLE
corrected title for SQL Saturday Florida 2026 event

### DIFF
--- a/_posts/2026/2026-10-17-sqlsaturday1158.markdown
+++ b/_posts/2026/2026-10-17-sqlsaturday1158.markdown
@@ -1,5 +1,5 @@
 ---
 layout: redirect
-title: "SQL Saturday Floripa 2026 (#1158)"
+title: "SQL Saturday Florida 2026 (#1158)"
 redirect:  https://sqlsaturday.com/2026-10-17-sqlsaturday1158/
 ---


### PR DESCRIPTION
"SQL Saturday Floripa 2026 (#1158)" should be "SQL Saturday Florida 2026 (#1158)"